### PR TITLE
Fix deploy workflow for master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,10 @@ name: 🚀 Deploy
 on:
   push:
     branches:
-      - v3
+      - master
       #- dev
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -115,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, typecheck, vitest, cypress]
     # only deploy main/dev branch on pushes
-    if: ${{ (github.ref == 'refs/heads/v3' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
     steps:
       - name: ⬇️ Checkout repo
@@ -138,7 +139,7 @@ jobs:
       #     FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: 🚀 Deploy Production
-        if: ${{ github.ref == 'refs/heads/v3' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app_name.outputs.value }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Update deploy workflow to trigger on `master` branch instead of `v3`
- Add `workflow_dispatch` trigger to allow manual runs from GitHub Actions tab
- Update deploy job conditions to match the new branch and support manual triggers

## Test plan
- [ ] Merge PR and verify the workflow runs automatically
- [ ] Verify "Run workflow" button appears on the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)